### PR TITLE
add info on removing PlayTools and rotate display area

### DIFF
--- a/PlayBook/src/keymapping/common_issues.md
+++ b/PlayBook/src/keymapping/common_issues.md
@@ -1,14 +1,32 @@
 # Common Issues
 
-### Keymap reliability issues are fixed by updating to macOS 13.1. You can ignore the following text if you have the update installed already. 
+## Unresponsive Keymapping
 
-Occasionally, keymaps may become unresponsive. This may occur if you use `command ⌘` + `tab` to quickly switch between apps before unlocking your mouse. If this occurs there are a couple of steps you can try.
+>__Note__: Most keymapping issues will fix themselves when you update to macOS Ventura 13.1. You can ignore the following information if you have the update installed already. If you are still having issues after updating, you can create a support post on the [_PlayCover Discord_](https://discord.gg/rMv5qxGTGC) to get help.
+
+Occasionally, keymaps may become unresponsive. This may occur if you use `command ⌘` + `tab` to quickly switch between apps before unlocking your mouse. If this happens there are a couple of steps you can try.
 
 1. Press `option ⌥` to release the mouse, and then press `option ⌥` again to enable keymapping. You may have to do this a couple times to regain control.
 2. Use `command ⌘` + `K` to open the Keymapping Editor, and press `command ⌘` + `K` again to close it.
 3. If the above doesn't work, restart the app.
 4. If the issue persists after restarting the app, save any work you have open and restart your Mac. 
 
-> __NOTE:__ When using shortcuts like `command ⌘` + `Q` to exit apps, the shortcut will not register with keymapping enabled. It may also result in unintended button presses if `Q` is mapped. Before quitting apps with shortcuts, you should therefore release your mouse and disable keymapping with `option ⌥`
+## Incorrect Screen Orientation 
+
+Some apps may rotate the display area incorrectly when you click on certain in-game buttons. Normally on a phone, these buttons require you to hold it in portrait orientation instead of landscape.
+
+For example: clicking on the **View** button in the Valkyrie menu in Honkai Impact 3rd. 
+
+<img width="400" alt="Screenshot 2023-01-16 at 3 07 45 PM" src="https://user-images.githubusercontent.com/78054566/212759243-396b07a3-775b-44b7-b620-a11e3f1ce608.png">
+
+When this happens, you can try these steps to fix it without having to restart the app.
+
+<img width="313" alt="Screenshot 2023-01-16 at 3 00 21 PM" src="https://user-images.githubusercontent.com/78054566/212760148-597aaaa9-56c5-4a61-b010-a2b20ad4bafe.png">
+
+1. Press `command ⌘` + `R` to rotate the window, you can also do this by clicking on `Menu bar` > `Keymapping` > `Rotate display area`.
+2. If doing the above does not work for the first time, keep pressing `command ⌘` + `R` until the app returns to its correct orientation.
+3. If the issue still remain after these steps, restart the app.
+
+>__Note__: This feature is only meant to fix rotation issues while the app is running. The rotation you selected will not be saved when you close the app.   
 
 ###### This information is up-to-date as of PlayCover `2.0.2`

--- a/PlayBook/src/keymapping/common_issues.md
+++ b/PlayBook/src/keymapping/common_issues.md
@@ -2,7 +2,7 @@
 
 ## Unresponsive Keymapping
 
->__Note__: Most keymapping issues will fix themselves when you update to macOS Ventura 13.1. You can ignore the following information if you have the update installed already. If you are still having issues after updating, you can create a support post on the [_PlayCover Discord_](https://discord.gg/rMv5qxGTGC) to get help.
+>__Note__: Most keymapping issues will fix themselves when you update to macOS Ventura 13.1. You can ignore the following information if you have the update installed already. If you are still having issues after updating, check the issues in [PlayTools](https://github.com/PlayCover/PlayTools) and [PlayCover](https://github.com/PlayCover/PlayCover/issues) before opening a new one. You may create a support post in the [Discussion forums](https://github.com/PlayCover/PlayCover/discussions) or the [_PlayCover Discord_](https://discord.gg/rMv5qxGTGC) for further help.
 
 Occasionally, keymaps may become unresponsive. This may occur if you use `command ⌘` + `tab` to quickly switch between apps before unlocking your mouse. If this happens there are a couple of steps you can try.
 

--- a/PlayBook/src/keymapping/using_making_keymaps.md
+++ b/PlayBook/src/keymapping/using_making_keymaps.md
@@ -43,6 +43,6 @@ Closing the Keymapping Editor will automatically **save** any changes you have m
 | Increase button size | Click on the button and press `command ⌘` + `▲` | Increase the size of the button coverage area | 
 | Decrease button size | Click on the button and press `command ⌘` + `▼` | Decrease the size of the button coverage area |
 
->__Note__: Input that cannot be mapped includes, but are not limited to: `fn`, `F1` to `F12` function keys, `option`, `command`, `numeric keyboard` extra keys, `middle mouse button`, `scroll wheel`, `power button`. 
+>__Note__: Input that cannot be mapped includes: `fn`, `option`, `command`, `scroll`, `power button`, `eject`, and `F` function keys that control volume. 
 
 ###### This information is up-to-date as of PlayCover `2.0.2`

--- a/PlayBook/src/keymapping/using_making_keymaps.md
+++ b/PlayBook/src/keymapping/using_making_keymaps.md
@@ -6,7 +6,7 @@ Many apps and games already have full keymaps available on our [Keymaps reposito
 
 ## Using Keymapping
 
-Once you've finished importing or creating your keymap, you can toggle it on or off by pressing the `option ⌥` key. Turning on keymapping will hide your cursor but you can still switch between other apps you have open using trackpad gestures or keyboard shortcuts. 
+Once you've finished importing or creating your keymap, you can toggle it on or off by pressing the `option ⌥` key. Turning on keymapping will lock the cursor to the app window, but you can still switch to other apps you have open using trackpad gestures or keyboard shortcuts. 
 
 ## Creating & Editing Keymaps
 
@@ -31,7 +31,7 @@ Closing the Keymapping Editor will automatically **save** any changes you have m
 | <img width="38" alt="Screenshot 2023-01-05 at 2 39 18 PM copy 3" src="https://user-images.githubusercontent.com/78054566/210871542-588e2aba-a2c3-4a60-ba17-59803c56cb4f.png"> | Directional Arrows | Adds an area for mouse input. Useful for camera control. Can be mapped to other keys to recreate draggable touchscreen aiming controls present in some games. |
 | <img width="38" alt="Screenshot 2023-01-05 at 2 39 18 PM copy 4" src="https://user-images.githubusercontent.com/78054566/210871677-84e9c784-6391-4e7b-951e-81ff1bd9a0a0.png"> | Mouse | Adds a single button bound to mouse control similar to Directional Arrows. Useful for games that require 360-degree movement control instead of 8-way directional movement. |
 
-> __Note__: On legacy versions (prior to 2.0.0 or PlayTools 2.0.1) of PlayCover, there may be RB and LB button types for adding left and right mouse button input.
+>__Note__: On legacy versions (prior to 2.0.0 or PlayTools 2.0.1) of PlayCover, there may be RB and LB button types for adding left and right mouse button input.
 
 #### Keymapping Editor usage instructions
 
@@ -42,5 +42,7 @@ Closing the Keymapping Editor will automatically **save** any changes you have m
 | Delete button | Click on the button and press `command ⌘` + `delete` | Removes the button from your keymap |
 | Increase button size | Click on the button and press `command ⌘` + `▲` | Increase the size of the button coverage area | 
 | Decrease button size | Click on the button and press `command ⌘` + `▼` | Decrease the size of the button coverage area |
+
+>__Note__: Input that cannot be mapped includes, but are not limited to: `fn`, `F1` to `F12` function keys, `option`, `command`, `numeric keyboard` extra keys, `middle mouse button`, `scroll wheel`, `power button`. 
 
 ###### This information is up-to-date as of PlayCover `2.0.2`

--- a/PlayBook/src/keymapping/using_making_keymaps.md
+++ b/PlayBook/src/keymapping/using_making_keymaps.md
@@ -43,6 +43,6 @@ Closing the Keymapping Editor will automatically **save** any changes you have m
 | Increase button size | Click on the button and press `command ⌘` + `▲` | Increase the size of the button coverage area | 
 | Decrease button size | Click on the button and press `command ⌘` + `▼` | Decrease the size of the button coverage area |
 
->__Note__: Input that cannot be mapped includes: `fn`, `option`, `command`, `scroll`, `power button`, and `eject`.
+>__Note__: Input that cannot be mapped includes: `fn`, `option`, `command`, `scroll`, `power button`, `eject`, and `volume up`, `volume down` and `mute` if they are stand alone keys.
 
 ###### This information is up-to-date as of PlayCover `2.0.2`

--- a/PlayBook/src/keymapping/using_making_keymaps.md
+++ b/PlayBook/src/keymapping/using_making_keymaps.md
@@ -43,6 +43,14 @@ Closing the Keymapping Editor will automatically **save** any changes you have m
 | Increase button size | Click on the button and press `command ⌘` + `▲` | Increase the size of the button coverage area | 
 | Decrease button size | Click on the button and press `command ⌘` + `▼` | Decrease the size of the button coverage area |
 
+#### Bindable keys
+
+Most keyboard keys can be mapped, including function keys and numeric keypad keys.
+
+In some cases gaming mouse buttons may be mapped, but they will be recognized as the middle mouse button `MMB`.
+
+All keys of [controllers](https://support.apple.com/en-us/HT210414) supported by Apple's [Game Controller API](https://developer.apple.com/documentation/gamecontroller) may be bound. Joystick and D-Pad binding is not supported.
+
 >__Note__: Input that cannot be mapped includes: `fn`, `option`, `command`, `scroll`, `power button`, `eject`, and `volume up`, `volume down` and `mute` if they are standalone keys.
 
 ###### This information is up-to-date as of PlayCover `2.0.2`

--- a/PlayBook/src/keymapping/using_making_keymaps.md
+++ b/PlayBook/src/keymapping/using_making_keymaps.md
@@ -43,6 +43,6 @@ Closing the Keymapping Editor will automatically **save** any changes you have m
 | Increase button size | Click on the button and press `command ⌘` + `▲` | Increase the size of the button coverage area | 
 | Decrease button size | Click on the button and press `command ⌘` + `▼` | Decrease the size of the button coverage area |
 
->__Note__: Input that cannot be mapped includes: `fn`, `option`, `command`, `scroll`, `power button`, `eject`, and `F` function keys that control volume. 
+>__Note__: Input that cannot be mapped includes: `fn`, `option`, `command`, `scroll`, `power button`, and `eject`.
 
 ###### This information is up-to-date as of PlayCover `2.0.2`

--- a/PlayBook/src/keymapping/using_making_keymaps.md
+++ b/PlayBook/src/keymapping/using_making_keymaps.md
@@ -43,6 +43,6 @@ Closing the Keymapping Editor will automatically **save** any changes you have m
 | Increase button size | Click on the button and press `command ⌘` + `▲` | Increase the size of the button coverage area | 
 | Decrease button size | Click on the button and press `command ⌘` + `▼` | Decrease the size of the button coverage area |
 
->__Note__: Input that cannot be mapped includes: `fn`, `option`, `command`, `scroll`, `power button`, `eject`, and `volume up`, `volume down` and `mute` if they are stand alone keys.
+>__Note__: Input that cannot be mapped includes: `fn`, `option`, `command`, `scroll`, `power button`, `eject`, and `volume up`, `volume down` and `mute` if they are standalone keys.
 
 ###### This information is up-to-date as of PlayCover `2.0.2`

--- a/PlayBook/src/settings/miscellaneous.md
+++ b/PlayBook/src/settings/miscellaneous.md
@@ -34,4 +34,8 @@ The following table will provide an in-depth explanation on the Metal 3 Performa
 
 This feature is meant for development and testing purposes only, and should not be enabled unless you know what you are doing.
 
+### Inject/Remove PlayTools
+
+By default, PlayTools are injected into the app when you add it to the App Library. PlayTools allows you to use keymapping, mouse mapping, change iOS device identifier, set custom resolutions, and more. However, these features may not be necessary for certain apps and may even cause issues. If the app you are using is not working properly as expected, you can try removing PlayTools.
+
 ###### This information is up-to-date as of PlayCover `2.0.2`


### PR DESCRIPTION
~~not sure where i should put the info for `cmd` + `R`~~

i just put it in common issues 

- [x] Talk about PlayTools removal and injection, possible consequences, etc
- [x] Mention what keys can be mapped or not (option key, F keys, numeric keyboard extra keys, middle button, scroll)
- [x] Document screen rotation and the fact that it is only officially intended to fix rotation issues during the execution of the app, and that the rotation status is not saved. 