### PR TITLE
Add Gitee download link

### DIFF
--- a/PlayBook/src/getting_started/download_playcover.md
+++ b/PlayBook/src/getting_started/download_playcover.md
@@ -8,7 +8,7 @@ If you have an Intel Mac, you can explore alternatives like Bootcamp or emulator
 
 ## Download
 
-You can download the [latest stable release](https://github.com/PlayCover/PlayCover/releases/latest), or download the [latest nightly version](https://nightly.link/playcover/playcover/workflows/2.nightly_release/develop) to test out experimental features before they are added to the stable release. 
+You can download the latest stable release from [Github](https://github.com/PlayCover/PlayCover/releases/latest) or [Gitee](https://gitee.com/playcover_community/PlayCover/releases), or download the [latest nightly version](https://nightly.link/playcover/playcover/workflows/2.nightly_release/develop) to test out experimental features before they are added to the stable release. 
 
 You can also [build from source](https://docs.playcover.io/building_from_source/install_prerequisites) if you wish to make contributions to PlayCover.
 


### PR DESCRIPTION
Chinese users may not be able to access Github to download the stable release of Playcover. Therefore, I created a mirror repo in Gitee, and created releases there for them to download.

Although a small portion of them can download from Github and share Playcover with others, the shared Playcover do have a risk of being modified. It is important that everyone can download Playcover by visiting our official website.

I'm not sure about the phrasing or how the organization in Gitee should be named tho. It's not named "Playcover" because that one was occupied by Wind 😭